### PR TITLE
Bug fix double canceled dex tx's, additional omnicore handling

### DIFF
--- a/database/omni_db_schema.psql
+++ b/database/omni_db_schema.psql
@@ -165,11 +165,11 @@ create table if not exists AddressesInTxs (					/* many-to-many */
 	, Protocol Protocol not null			/* initially 'Bitcoin' or 'Mastercoin' */
 	, TxDBSerialNum int8 not null default -1	/* db internal identifier for each tx, for faster joins */
 	, AddressTxIndex int2 not null			/* position in the input or output list */
-	, LinkedTxDBSerialNum int8 not null default -1	/* tx with the associated output for inputs, or with the associated input for outputs */
 	, AddressRole AddressRole not null		
 	, BalanceAvailableCreditDebit numeric(19) null		/* how much the balance changed */
 	, BalanceReservedCreditDebit numeric(19) null		/* how much the balance changed */
 	, BalanceAcceptedCreditDebit numeric(19) null		/* how much the balance changed */
+	, LinkedTxDBSerialNum int8 not null default -1	/* tx with the associated output for inputs, or with the associated input for outputs */
 
 /*	, primary key (Address, TxDBSerialNum, PropertyID, AddressRole) */
 /*	, foreign key (Address, Protocol, PropertyID) references AddressBalances */


### PR DESCRIPTION
Double canceled dev tx's are valid but second tx was accidentally inserting into db.  cleanup handling, 
processing past closed crowdsales was accidentally updating balance with addedissuetokens more than once, handle only processing it once
clean up schema to match production layout properly. 