### PR TITLE
about this condition  judgment

### DIFF
--- a/sql.py
+++ b/sql.py
@@ -1595,7 +1595,7 @@ def insertTxAddr(rawtx, Protocol, TxDBSerialNum, Block):
         if Valid:
           updateBalance(Address, Protocol, PropertyID, Ecosystem, BalanceAvailableCreditDebit, BalanceReservedCreditDebit, BalanceAcceptedCreditDebit, TxDBSerialNum)
  
-        if 'referenceaddress' in rawtx['result'] and rawtx['result']['referenceaddress'] not in [None,'']:
+        if 'referenceaddress' in rawtx['result']:
 	  #credit the receiver
           Address = rawtx['result']['referenceaddress']
           AddressRole="recipient"


### PR DESCRIPTION
if you append this condition `and rawtx['result']['referenceaddress'] not in [None,'']:`; then the Semantics will be different in the past. Because the referenceAddress maybe a NULL string(if one transaction have only output, and this output is OP_RETURN script, this condition, the output corresponding referenceaddress is NULL string). So,   if have this kind of transactions in the past, these transaction data status is different in the engine and omnicore